### PR TITLE
Fix tile connections

### DIFF
--- a/BonsaiWorldSim.Tests/BonsaiWorldSim.Tests.csproj
+++ b/BonsaiWorldSim.Tests/BonsaiWorldSim.Tests.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net5.0-windows</TargetFramework>
+
+        <IsPackable>false</IsPackable>
+
+        <OutputType>WinExe</OutputType>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4"/>
+        <PackageReference Include="xunit" Version="2.4.1"/>
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+        <PackageReference Include="coverlet.collector" Version="3.0.2">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\BonsaiWorldSim\BonsaiWorldSim.csproj"/>
+    </ItemGroup>
+
+</Project>

--- a/BonsaiWorldSim.Tests/UnitTest1.cs
+++ b/BonsaiWorldSim.Tests/UnitTest1.cs
@@ -1,0 +1,119 @@
+using System.Linq;
+using Xunit;
+
+namespace BonsaiWorldSim.Tests
+{
+	public class TileConnections
+	{
+		[Theory]
+		[InlineData(
+			1,
+			0,
+			0.5f,
+			-1
+		)]
+		[InlineData(
+			999,
+			888,
+			777,
+			666
+		)]
+		public void Connect_GivenNonOverlappingTiles_ShouldCreateMutualConnections(float aX,
+			float                                                                        aY,
+			float                                                                        bX,
+			float                                                                        bY)
+		{
+			// Arrange
+			Simulation.Tiles.Clear();
+			var tileA = new Tile(new(aX, aY));
+			var tileB = new Tile(new(bX, bY));
+
+			// Act
+			tileA.Connect(tileB.Position - tileA.Position);
+
+			// Assert: tiles are connected to each other at all
+			var isTileAToBConnected = tileA.Connections.ContainsValue(tileB);
+			var isTileBToAConnected = tileB.Connections.ContainsValue(tileA);
+			Assert.True(isTileAToBConnected && isTileBToAConnected, "Tiles didn't establish mutual connections.");
+
+			// Assert: tiles are connected to each other with proper keys
+			var tileAToBDirection = tileA.Connections.FirstOrDefault(connection => connection.Value == tileB).Key;
+			var tileBToADirection = tileB.Connections.FirstOrDefault(connection => connection.Value == tileA).Key;
+			Assert.True(
+				tileAToBDirection == (tileBToADirection * -1),
+				"Tile connections aren't at inverted directions."
+			);
+		}
+
+		[Theory]
+		[InlineData(
+			0,
+			0,
+			0,
+			0
+		)]
+		[InlineData(
+			9,
+			9,
+			9,
+			9
+		)]
+		public void Connect_GivenOverlappingTiles_ShouldNotCreateConnections(float aX,
+		                                                                     float aY,
+		                                                                     float bX,
+		                                                                     float bY)
+		{
+			// Arrange
+			Simulation.Tiles.Clear();
+			var tileA = new Tile(new(aX, aY));
+			var tileB = new Tile(new(bX, bY));
+
+			// Act
+			tileA.Connect(tileB.Position - tileA.Position);
+
+			// Assert: tiles are connected to each other at all
+			var isTileAToBConnected = tileA.Connections.ContainsValue(tileB);
+			var isTileBToAConnected = tileB.Connections.ContainsValue(tileA);
+			Assert.False(isTileAToBConnected && isTileBToAConnected, "Tiles didn't establish mutual connections.");
+		}
+
+		[Theory]
+		[InlineData(
+			1,
+			0,
+			0.5f,
+			-1
+		)]
+		[InlineData(
+			999,
+			888,
+			777,
+			666
+		)]
+		public void Disconnect_ShouldRemoveConnection(float aX,
+		                                              float aY,
+		                                              float bX,
+		                                              float bY)
+		{
+			// Arrange
+			Simulation.Tiles.Clear();
+			var tileA         = new Tile(new(aX, aY));
+			var tileB         = new Tile(new(bX, bY));
+			var directionAtoB = tileB.Position - tileA.Position;
+			tileA.Connect(directionAtoB);
+
+			// Act
+			tileA.Disconnect(directionAtoB);
+
+			// Assert: tiles are disconnected from each other
+			var isTileAToBConnected = tileA.Connections.ContainsValue(tileB);
+			var isTileBToAConnected = tileB.Connections.ContainsValue(tileA);
+			Assert.True(!isTileAToBConnected && !isTileBToAConnected, "Tiles didn't disconnect.");
+
+			// Assert: keys are totally free
+			var isTileAKeyFree = !tileA.Connections.ContainsKey(directionAtoB);
+			var isTileBKeyFree = !tileB.Connections.ContainsKey(directionAtoB);
+			Assert.True(isTileAKeyFree && isTileBKeyFree, "Keys weren't freed up.");
+		}
+	}
+}

--- a/BonsaiWorldSim.sln
+++ b/BonsaiWorldSim.sln
@@ -2,6 +2,8 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BonsaiWorldSim", "BonsaiWorldSim\BonsaiWorldSim.csproj", "{591EB572-2B50-426A-9046-8DCFE1865D8C}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BonsaiWorldSim.Tests", "BonsaiWorldSim.Tests\BonsaiWorldSim.Tests.csproj", "{446BC892-EA34-44F2-9DDC-915F2303CCC4}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -12,5 +14,9 @@ Global
 		{591EB572-2B50-426A-9046-8DCFE1865D8C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{591EB572-2B50-426A-9046-8DCFE1865D8C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{591EB572-2B50-426A-9046-8DCFE1865D8C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{446BC892-EA34-44F2-9DDC-915F2303CCC4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{446BC892-EA34-44F2-9DDC-915F2303CCC4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{446BC892-EA34-44F2-9DDC-915F2303CCC4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{446BC892-EA34-44F2-9DDC-915F2303CCC4}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/BonsaiWorldSim.sln.DotSettings.user
+++ b/BonsaiWorldSim.sln.DotSettings.user
@@ -1,16 +1,4 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
-	<s:String x:Key="/Default/Environment/UnitTesting/UnitTestSessionStore/Sessions/=659d4c1b_002D85c9_002D432c_002D8629_002D60d02bf0690c/@EntryIndexedValue">&lt;SessionState ContinuousTestingMode="0" IsActive="True" Name="Connect_ShouldResultInMutualConnections(aX: 1, aY: 0, bX: 0.5, bY: -1)" xmlns="urn:schemas-jetbrains-com:jetbrains-ut-session"&gt;&#xD;
-  &lt;TestAncestor&gt;&#xD;
-    &lt;TestId&gt;xUnit::446BC892-EA34-44F2-9DDC-915F2303CCC4::net5.0-windows7.0::BonsaiWorldSim.Tests.TileConnections&lt;/TestId&gt;&#xD;
-  &lt;/TestAncestor&gt;&#xD;
-&lt;/SessionState&gt;</s:String>
-	<s:String x:Key="/Default/Environment/UnitTesting/UnitTestSessionStore/Sessions/=c2aa5297_002D98c1_002D4478_002D838b_002D2ca8bfa87711/@EntryIndexedValue">&lt;SessionState ContinuousTestingMode="0" Name="Connect_ShouldResultInMutualConnections #2" xmlns="urn:schemas-jetbrains-com:jetbrains-ut-session"&gt;&#xD;
-  &lt;TestAncestor&gt;&#xD;
-    &lt;TestId&gt;xUnit::446BC892-EA34-44F2-9DDC-915F2303CCC4::net5.0-windows7.0::BonsaiWorldSim.Tests.UnitTest1&lt;/TestId&gt;&#xD;
-  &lt;/TestAncestor&gt;&#xD;
-&lt;/SessionState&gt;</s:String>
-	<s:String x:Key="/Default/Environment/UnitTesting/UnitTestSessionStore/Sessions/=f3ef0be6_002D949a_002D4fdb_002D82bf_002Dc4565da477a5/@EntryIndexedValue">&lt;SessionState ContinuousTestingMode="0" Name="Connect_ShouldResultInMutualConnections" xmlns="urn:schemas-jetbrains-com:jetbrains-ut-session"&gt;&#xD;
-  &lt;TestAncestor&gt;&#xD;
-    &lt;TestId&gt;xUnit::446BC892-EA34-44F2-9DDC-915F2303CCC4::net5.0-windows7.0::BonsaiWorldSim.Tests.UnitTest1&lt;/TestId&gt;&#xD;
-  &lt;/TestAncestor&gt;&#xD;
+	<s:String x:Key="/Default/Environment/UnitTesting/UnitTestSessionStore/Sessions/=4c8f18e4_002D8764_002D4030_002D8efc_002D14d66bd3f45f/@EntryIndexedValue">&lt;SessionState ContinuousTestingMode="0" IsActive="True" Name="All tests from Solution" xmlns="urn:schemas-jetbrains-com:jetbrains-ut-session"&gt;&#xD;
+  &lt;Solution /&gt;&#xD;
 &lt;/SessionState&gt;</s:String></wpf:ResourceDictionary>

--- a/BonsaiWorldSim.sln.DotSettings.user
+++ b/BonsaiWorldSim.sln.DotSettings.user
@@ -1,0 +1,16 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/Environment/UnitTesting/UnitTestSessionStore/Sessions/=659d4c1b_002D85c9_002D432c_002D8629_002D60d02bf0690c/@EntryIndexedValue">&lt;SessionState ContinuousTestingMode="0" IsActive="True" Name="Connect_ShouldResultInMutualConnections(aX: 1, aY: 0, bX: 0.5, bY: -1)" xmlns="urn:schemas-jetbrains-com:jetbrains-ut-session"&gt;&#xD;
+  &lt;TestAncestor&gt;&#xD;
+    &lt;TestId&gt;xUnit::446BC892-EA34-44F2-9DDC-915F2303CCC4::net5.0-windows7.0::BonsaiWorldSim.Tests.TileConnections&lt;/TestId&gt;&#xD;
+  &lt;/TestAncestor&gt;&#xD;
+&lt;/SessionState&gt;</s:String>
+	<s:String x:Key="/Default/Environment/UnitTesting/UnitTestSessionStore/Sessions/=c2aa5297_002D98c1_002D4478_002D838b_002D2ca8bfa87711/@EntryIndexedValue">&lt;SessionState ContinuousTestingMode="0" Name="Connect_ShouldResultInMutualConnections #2" xmlns="urn:schemas-jetbrains-com:jetbrains-ut-session"&gt;&#xD;
+  &lt;TestAncestor&gt;&#xD;
+    &lt;TestId&gt;xUnit::446BC892-EA34-44F2-9DDC-915F2303CCC4::net5.0-windows7.0::BonsaiWorldSim.Tests.UnitTest1&lt;/TestId&gt;&#xD;
+  &lt;/TestAncestor&gt;&#xD;
+&lt;/SessionState&gt;</s:String>
+	<s:String x:Key="/Default/Environment/UnitTesting/UnitTestSessionStore/Sessions/=f3ef0be6_002D949a_002D4fdb_002D82bf_002Dc4565da477a5/@EntryIndexedValue">&lt;SessionState ContinuousTestingMode="0" Name="Connect_ShouldResultInMutualConnections" xmlns="urn:schemas-jetbrains-com:jetbrains-ut-session"&gt;&#xD;
+  &lt;TestAncestor&gt;&#xD;
+    &lt;TestId&gt;xUnit::446BC892-EA34-44F2-9DDC-915F2303CCC4::net5.0-windows7.0::BonsaiWorldSim.Tests.UnitTest1&lt;/TestId&gt;&#xD;
+  &lt;/TestAncestor&gt;&#xD;
+&lt;/SessionState&gt;</s:String></wpf:ResourceDictionary>

--- a/BonsaiWorldSim/HexMap.cs
+++ b/BonsaiWorldSim/HexMap.cs
@@ -8,14 +8,14 @@ namespace BonsaiWorldSim
 {
 	public class HexMap
 	{
-		const int   HEX_SIZE                = 10;
+		const int   HEX_SIZE                = 20;
 		const float HEX_WIDTH_RATIO         = 0.86602540378f; // sqrt(3) / 2
 		const float HEX_HEIGHT              = HEX_SIZE;
 		const float HEX_WIDTH               = HEX_SIZE * HEX_WIDTH_RATIO;
 		const float HEX_UPPER_CORNER_HEIGHT = 0.25f;
 		const float HEX_LOWER_CORNER_HEIGHT = 0.75f;
 
-		public HexMap(Canvas canvas) { Canvas = canvas; }
+		public HexMap(Canvas canvas) => Canvas = canvas;
 
 		Canvas Canvas { get; }
 
@@ -60,11 +60,13 @@ namespace BonsaiWorldSim
 			AddHex(Vector2.Zero, null, Brushes.Fuchsia);
 
 			foreach (var tile in tiles)
+			{
 				AddHex(tile.Position, tile.Color, null);
+			}
 
 			foreach (var tile in tiles)
 			{
-				foreach (var (key, connection) in tile.Connections)
+				foreach (var connection in tile.Connections)
 				{
 					Canvas.Children.Add(
 						new Line

--- a/BonsaiWorldSim/MainWindow.xaml
+++ b/BonsaiWorldSim/MainWindow.xaml
@@ -68,7 +68,9 @@
 				</Border>
 				<Border Grid.Row = "1"
 						Grid.Column = "1">
-					<Button Click = "ButtonBase_OnClick">Expand</Button>
+					<Button Click = "ButtonBase_OnClick">
+						<AccessText>_Expand</AccessText>
+					</Button>
 				</Border>
 			</Grid>
 		</ScrollViewer>

--- a/BonsaiWorldSim/MainWindow.xaml.cs
+++ b/BonsaiWorldSim/MainWindow.xaml.cs
@@ -8,6 +8,19 @@ namespace BonsaiWorldSim
 	/// </summary>
 	public partial class MainWindow
 	{
+		const int EXPANSIONS_PER_BUTTON_PRESS = 100;
+
+		static int LastUsedId { get; set; } = 0;
+
+		public static string NextId
+		{
+			get
+			{
+				LastUsedId++;
+				return $"{LastUsedId:000000}";
+			}
+		}
+
 		public MainWindow()
 		{
 			InitializeComponent();
@@ -61,12 +74,14 @@ namespace BonsaiWorldSim
 
 		void ButtonBase_OnClick(object sender, RoutedEventArgs e)
 		{
-			for (var i = 0; i < 100; i++)
+			for (var i = 0; i < EXPANSIONS_PER_BUTTON_PRESS; i++)
 			{
 				Simulation.Expand();
 			}
 
 			HexMap.DrawHexes(Simulation.Tiles);
 		}
+
+		public static void Popup(string message) { MessageBox.Show(message); }
 	}
 }

--- a/BonsaiWorldSim/MainWindow.xaml.cs
+++ b/BonsaiWorldSim/MainWindow.xaml.cs
@@ -8,7 +8,7 @@ namespace BonsaiWorldSim
 	/// </summary>
 	public partial class MainWindow
 	{
-		const int EXPANSIONS_PER_BUTTON_PRESS = 50;
+		const int EXPANSIONS_PER_BUTTON_PRESS = 1;
 
 		public MainWindow()
 		{

--- a/BonsaiWorldSim/MainWindow.xaml.cs
+++ b/BonsaiWorldSim/MainWindow.xaml.cs
@@ -8,18 +8,7 @@ namespace BonsaiWorldSim
 	/// </summary>
 	public partial class MainWindow
 	{
-		const int EXPANSIONS_PER_BUTTON_PRESS = 100;
-
-		static int LastUsedId { get; set; } = 0;
-
-		public static string NextId
-		{
-			get
-			{
-				LastUsedId++;
-				return $"{LastUsedId:000000}";
-			}
-		}
+		const int EXPANSIONS_PER_BUTTON_PRESS = 50;
 
 		public MainWindow()
 		{
@@ -29,6 +18,17 @@ namespace BonsaiWorldSim
 
 			HexMap = new(Canvas);
 			HexMap.DrawHexes(Simulation.Tiles);
+		}
+
+		static int LastUsedId { get; set; }
+
+		public static string NextId
+		{
+			get
+			{
+				LastUsedId++;
+				return $"{LastUsedId:000000}";
+			}
 		}
 
 		bool       IsDragged  { get; set; }

--- a/BonsaiWorldSim/Simulation.cs
+++ b/BonsaiWorldSim/Simulation.cs
@@ -91,8 +91,9 @@ namespace BonsaiWorldSim
 
 		static void NewTurn()
 		{
-			foreach (var tile in Tiles)
+			foreach (var tile in Tiles.ToArray()) // ToArray to avoid self-modifying collection
 			{
+				ProcessOverlappingTilesAtPosition(tile.Position);
 				tile.AttemptedTranslation = false;
 			}
 		}
@@ -135,11 +136,20 @@ namespace BonsaiWorldSim
 			}
 
 			// push new tiles (all connected together) out from the center
-			var degrees = Random.Next(360);
-			while (newTiles.Any(tile => tile.Position.Length() < CENTER_HOLE_RADIUS))
+			var degrees  = Random.Next(360);
+			var tries    = 0;
+			var maxTries = 100;
+
+			// while (newTiles.Any(tile => tile.Position.Length() < CENTER_HOLE_RADIUS))
+			while (Tiles.Any(tile => tile.Position == Vector2.Zero))
 			{
 				NewTurn();
 				newTiles[0].Translate(degrees);
+				tries++;
+				if (tries > maxTries)
+				{
+					break;
+				}
 			}
 
 			foreach (var tile in newTiles)

--- a/BonsaiWorldSim/Tile.cs
+++ b/BonsaiWorldSim/Tile.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.IO.Packaging;
 using System.Linq;
 using System.Numerics;
 using System.Windows.Media;
@@ -28,9 +27,7 @@ namespace BonsaiWorldSim
 			Simulation.Tiles.Add(this);
 		}
 
-		public override string ToString() => $"t{Id}";
-
-		string Id { get; set; }
+		string Id { get; }
 
 		public Vector2 Position             { get; set; }
 		public Brush   Color                { get; set; }
@@ -49,8 +46,16 @@ namespace BonsaiWorldSim
 			}
 		}
 
+		public override string ToString() => $"t{Id}";
+
 		public void Connect(Vector2 direction)
 		{
+			// give up if the tile is overlapping with this one
+			if (direction == Vector2.Zero)
+			{
+				return;
+			}
+
 			// give up if there's already a connection in that direction
 			if (Connections.ContainsKey(direction))
 			{
@@ -67,6 +72,12 @@ namespace BonsaiWorldSim
 			// connect the tiles
 			Connections.Add(direction, connection);
 			connection.Connections.Add(direction * -1, this);
+
+			// DELETEME: sanity check
+			if (!connection.Connections.ContainsValue(this) || !Connections.ContainsValue(connection))
+			{
+				throw new("Uh oh!");
+			}
 		}
 
 		public void Disconnect(Vector2 direction)
@@ -77,13 +88,7 @@ namespace BonsaiWorldSim
 				return;
 			}
 
-			// TODO: fix connections sometimes not being mutual
 			var connection = Connections[direction];
-
-			if (!connection.Connections.ContainsValue(this))
-			{
-				throw new("Connection not mutual!");
-			}
 
 			// disconnect the tiles
 			Connections.Remove(direction);
@@ -117,6 +122,8 @@ namespace BonsaiWorldSim
 			if ((tileInTheWay != null) && !Connections.ContainsValue(tileInTheWay))
 			{
 				tileInTheWay.Translate(degrees);
+
+				// tileInTheWay.Translate(translation);
 			}
 
 			// if this would move the tile into the center hole, break all connections and don't translate


### PR DESCRIPTION
Tiles were buggy due to overly complex connection and movement logic. After much testing and debugging, `Tile` was completely rewritten.